### PR TITLE
fix(mge/build): update cmake_minimum_required VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13.0)
+cmake_minimum_required(VERSION 3.14.4)
 
 include (cmake/FetchMegBrainVersion.cmake)
 project(MegEngine LANGUAGES C CXX VERSION ${MGB_VER_STRING})


### PR DESCRIPTION
Fixed the cmake minimum required version according to the case mentioned in Issue #57 opened by @zjd1988 .   


Refs: [Official Document](https://cmake.org/cmake/help/git-stage/policy/CMP0086.html)
```
Starting with CMake 3.14, UseSWIG passes option -module <module_name> to SWIG compiler if the file property SWIG_MODULE_NAME is specified. This policy provides compatibility with projects that expect the legacy behavior.
```