### PR TITLE
Update prepare.sh to fix git version error

### DIFF
--- a/third_party/prepare.sh
+++ b/third_party/prepare.sh
@@ -2,7 +2,7 @@
 
 git_version=$(git --version)
 if [ >= "1.8.4" ]; then
-    echo "Since git 1.8.4 (August 2013), and commit 091a6eb, you don't have to be at top-level to run git submodule update."
+    echo "Since git 1.8.4 (August 2013), you don't have to be at top-level to run git submodule update."
 else
     echo "You have to update your git version to 1.8.4 or later."
     exit -1

--- a/third_party/prepare.sh
+++ b/third_party/prepare.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -e
 
+git_version=$(git --version)
+if [ >= "1.8.4" ]; then
+    echo "Since git 1.8.4 (August 2013), and commit 091a6eb, you don't have to be at top-level to run git submodule update."
+else
+    echo "You have to update your git version to 1.8.4 or later."
+    exit -1
+fi
+
 cd $(dirname $0)
 
 git submodule sync


### PR DESCRIPTION
Check if the git version is greater than 1.8.4 to avoid the git submodule error. Since git 1.8.4 (August 2013), and commit 091a6eb, you don't have to be at top-level to run git submodule update.