### PR TITLE
fix(python_module): fix syntaxwarning when importing megengine at the time

### DIFF
--- a/python_module/megengine/_internal/craniotome.py
+++ b/python_module/megengine/_internal/craniotome.py
@@ -308,7 +308,7 @@ class CraniotomeBase(_mgb.CraniotomeDesc, metaclass=_CraniotomeBaseMeta):
 
         for i in range(len(rst)):
             cur = rst[i]
-            if cur is 0:
+            if isinstance(cur, int) and cur == 0:
                 rst[i] = _mgb.SymbolVar()
             else:
                 assert isinstance(cur, _mgb.SymbolVar), (

--- a/python_module/megengine/core/function.py
+++ b/python_module/megengine/core/function.py
@@ -46,7 +46,8 @@ class _OverrideGradientCraniotome(mgb.craniotome.CraniotomeBase):
             *(Tensor(x) if x is not None else None for x in out_grad)
         )
         # pylint: disable=literal-comparison
-        if isinstance(grads, Tensor) or grads is None or grads is 0:
+        if isinstance(grads, Tensor) or grads is None or \
+            (isinstance(grads, int) and grads == 0):
             grads = (grads,)
         assert (
             len(grads) == self.__nr_inputs__ - self.__nr_outputs__
@@ -55,7 +56,8 @@ class _OverrideGradientCraniotome(mgb.craniotome.CraniotomeBase):
         )
         # pylint: disable=literal-comparison
         return (
-            list(x._symvar if x is not None and x is not 0 else 0 for x in grads)
+            list(x._symvar if x is not None and \
+                (not isinstance(x, int) or x != 0) else 0 for x in grads)
             + [0] * self.__nr_outputs__
         )
 


### PR DESCRIPTION
Fix the SyntaxWarning about is and is not.
When importing megengine in the first time in Python 3.8, it will raise the following warning:

```
/home/wkcn/proj/megengine/build/python_module/megengine/_internal/craniotome.py:311: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if cur is 0:
/home/wkcn/proj/megengine/build/python_module/megengine/core/function.py:49: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if isinstance(grads, Tensor) or grads is None or grads is 0:
/home/wkcn/proj/megengine/build/python_module/megengine/core/function.py:58: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  list(x._symvar if x is not None and x is not 0 else 0 for x in grads)
```