### PR TITLE
fix(git): make git version check works

### DIFF
--- a/third_party/prepare.sh
+++ b/third_party/prepare.sh
@@ -2,6 +2,15 @@
 
 cd $(dirname $0)
 
+requiredGitVersion="1.8.4"
+currentGitVersion="$(git --version | awk '{print $3}')"
+if [ "$(printf '%s\n' "$requiredGitVersion" "$currentGitVersion" | sort -V | head -n1)" = "$currentGitVersion" ]; then
+    echo "Found Git: $(which git). (foud version $currentGitVersion, required version >= $requiredGitVersion)"
+else
+    echo "Please update your Git version. (foud version $currentGitVersion, required version >= $requiredGitVersion)"
+    exit 1
+fi
+
 git submodule sync
 git submodule update --init intel-mkl-dnn
 git submodule update --init Halide


### PR DESCRIPTION
Correct the script not worked in #76 which would like to solve problem that git submodule update must be at top-level.