### PR TITLE
fix(git): make git version check work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,15 @@
-/build/
+# Build
+build/
+output/
+
+# Cache
 __pycache__/
+.ccls-cache/
+
+# Editor and IDE Config
+.vscode/
+.vs/
+.idea/
+
+# CMake
+compile_commands.json

--- a/third_party/prepare.sh
+++ b/third_party/prepare.sh
@@ -1,14 +1,13 @@
 #!/bin/bash -e
 
-git_version=$(git --version)
-if [ >= "1.8.4" ]; then
-    echo "Since git 1.8.4 (August 2013), you don't have to be at top-level to run git submodule update."
-else
-    echo "You have to update your git version to 1.8.4 or later."
+cd $(dirname $0)
+
+requiredGitVersion="1.8.4"
+currentGitVersion="$(git --version | awk '{print $3}')"
+if [ "$(printf '%s\n' "$requiredGitVersion" "$currentGitVersion" | sort -V | head -n1)" = "$currentGitVersion" ]; then
+    echo "Please update your Git version. (foud version $currentGitVersion, required version >= $requiredGitVersion)"
     exit -1
 fi
-
-cd $(dirname $0)
 
 git submodule sync
 


### PR DESCRIPTION
Correct the script not worked in #76 which would like to solve problem that git submodule update must be at top-level.