### PR TITLE
Using time.perf_counter() insead of time.time()

### DIFF
--- a/imperative/python/megengine/random/rng.py
+++ b/imperative/python/megengine/random/rng.py
@@ -17,7 +17,7 @@ def _random_seed_generator():
     if _rng is None:
         from ..distributed.group import get_rank
 
-        seed(seed=int(time.time()) + get_rank())
+        seed(seed=((int(time.perf_counter()*1000) & 0x0000_FFFF_FFFF_FFFF ) << 16) + get_rank())
     while True:
         yield _rng.random_raw()
 


### PR DESCRIPTION
使用`time.perf_counter_ns()`代替#104 中提到的`uuid`，这样也可以避免出现恶性BUG
左移16位基本保证了绝大多数情况下get_rank生成的结果不会造成冲突