### PR TITLE
Fix prepare

### DIFF
--- a/third_party/apply-patches.sh
+++ b/third_party/apply-patches.sh
@@ -5,6 +5,8 @@ function apply_cpuinfo_patches() {
     if [ -d "./cpuinfo" ]; then
         cp ./patches/0001-fix-arm-linux-fix-uclibc-build-error.patch cpuinfo/
         pushd cpuinfo >/dev/null
+        git config user.name "$1"
+        git config user.email "$2"
         git am --abort || true
         git rebase --abort || true
         git reset --hard

--- a/third_party/prepare.sh
+++ b/third_party/prepare.sh
@@ -31,8 +31,18 @@ git submodule update --init gtest
 git submodule update --init cutlass
 
 git submodule update --init cpuinfo
+
+name=`git config --get user.name`
+if [ -z "$name" ]; then
+    name="default"
+fi
+email=`git config --get user.email`
+if [ -z "$email" ]; then
+    email="default"
+fi
+
 source ./apply-patches.sh
-apply_cpuinfo_patches
+apply_cpuinfo_patches ${name} ${email}
 
 git submodule update --init OpenBLAS
 git submodule update --init libzmq


### PR DESCRIPTION
修復 ./third_party/prepare.sh 時，沒有設置 user.name 和 user.email 導致的 `git` 命令的失敗。

嘗試取 git config user.name 和 user.email，沒有則設為`default`，傳給腳本。