### PR TITLE
ci(yaml): fix only pull request run ci lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   check-commit:
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request }}
     steps:
       - uses: actions/checkout@v2.3.1
         with:
@@ -18,6 +19,7 @@ jobs:
 
   check-format:
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request }}
     steps:
       - uses: actions/checkout@v2.3.1
         with:


### PR DESCRIPTION
Only allows pull request event to run `check-commit`, `check-format`.