### PR TITLE
Update xornet.py: 使其可以在mge1.5.0上运行

### DIFF
--- a/sdk/xor-deploy/xornet.py
+++ b/sdk/xor-deploy/xornet.py
@@ -51,6 +51,7 @@ def main():
     def train_fun(data, label):
         opt.clear_grad()
         with gm:
+            data = mge.Tensor(data)
             pred = net(data)
             loss = F.loss.cross_entropy(pred, label)
             gm.backward(loss)
@@ -58,12 +59,14 @@ def main():
         return pred, loss
 
     def val_fun(data, label):
+        data = mge.Tensor(data)
         pred = net(data)
         loss = F.loss.cross_entropy(pred, label)
         return pred, loss
 
     @trace(symbolic=True, capture_as_const=True)
     def pred_fun(data):
+        data = mge.Tensor(data)
         pred = net(data)
         pred_normalized = F.softmax(pred)
         return pred_normalized


### PR DESCRIPTION
`xornet.py`里面`train_fun`&`val_fun`的部分缺失了将np.array转换为tensor的步骤，会导致在megengine1.5.0上运行报错
```
TypeError: op MatrixMul expect type Tensor as inputs, got numpy.ndarray actually
```
而在1.4.0上可以顺利运行
所以将转换部分的代码`data = mge.Tensor(data)`加入即可顺利运行
同时，为了整齐性，虽然`pred_fun`的部分已经在外部进行了数据的转换，还是加上了转换部分的代码。