### PR TITLE
update functional.arange docstring

### DIFF
--- a/imperative/python/megengine/functional/tensor.py
+++ b/imperative/python/megengine/functional/tensor.py
@@ -1069,32 +1069,39 @@ def arange(
     dtype="float32",
     device: Optional[CompNode] = None,
 ) -> Tensor:
-    r"""Returns a tensor with values from start to stop with adjacent interval step.
+    r"""Returns evenly spaced values within the half-open interval ``[start, stop)`` as a one-dimensional tensor. 
+
+    Note:
+        * This function is not completely consistent with the specifications in the
+          `Python array API standard <https://data-apis.org/array-api/latest/>`_ --
+          The data type would not be inferred from ``start``, ``stop`` and ``step``.
+        * This function cannot guarantee that the interval does not include the stop value in those cases 
+          where step is not an integer and floating-point rounding errors affect the length of the output tensor.
 
     Args:
-        start: starting value of the squence, shoule be scalar.
-        stop: ending value of the squence, shoule be scalar.
-        step: gap between each pair of adjacent values. Default: 1
-        dtype: result data type.
+        start: if ``stop`` is specified, the start of interval (inclusive); otherwise, 
+            the end of the interval (exclusive). If ``stop`` is not specified, the default starting value is ``0``. 
+        stop: the end of the interval. Default: ``None``.
+        step: the distance between two adjacent elements ( ``out[i+1] - out[i]`` ). Must not be 0 ; 
+            may be negative, this results i an empty tensor if stop >= start . Default: 1 . 
+
+    Keyword args:
+        dtype( :attr:`.Tensor.dtype` ): output tensor data type. Default: ``float32``.
+        device( :attr:`.Tensor.device` ): device on which to place the created tensor. Default: ``None``.
 
     Returns:
-        generated tensor.
+        A one-dimensional tensor containing evenly spaced values.
+
+        The length of the output tensor must be ``ceil((stop-start)/step)`` 
+        if ``stop - start`` and ``step`` have the same sign, and length 0 otherwise.
 
     Examples:
 
-        .. testcode::
+        >>> F.arange(5)
+        Tensor([0. 1. 2. 3. 4.], device=xpux:0)
+        >>> F.arange(1, 4)
+        Tensor([1. 2. 3.], device=xpux:0)
 
-            import numpy as np
-            import megengine.functional as F
-
-            a = F.arange(5)
-            print(a.numpy())
-
-        Outputs:
-
-        .. testoutput::
-
-            [0. 1. 2. 3. 4.]
     """
     if stop is None:
         start, stop = 0, start


### PR DESCRIPTION
根据 #227 中的描述改进 `megengine.functional.arange` API 文档，改进方式如下：

- 按照 《[Python 文档字符串风格指南](https://megengine.org.cn/doc/stable/zh/development/contribute-to-docs/python-docstring-style-guide.html)》中的说明，发现 `arange` 在《数组 API 标准》中存在 [标准定义](https://data-apis.org/array-api/latest/API_specification/creation_functions.html#arange-start-stop-none-step-1-dtype-none-device-none)，因此使用了《标准》中的文档字符串作为描述内容。
- 为 `type` 和 `device` 两个参数人为添加了类型提示， 指向对应的 Tensor methods, 覆盖掉原来的 `CompNode` TypeHint.
- 替换掉了 `testcode` 风格的样例，使用 `>>>` 标准 doctest 风格。

疑惑：是否需要像 [numpy.arange](https://numpy.org/doc/stable/reference/generated/numpy.arange.html) 一样对函数签名进行重写？效果如下：

![image](https://user-images.githubusercontent.com/21091736/140281956-920bf0c4-75c5-4437-8069-def00e355e63.png)

这样的函数签名能够方便用户认识到 ``start`` 参数是一个可选项，但这样的话需要对应地修改参数使用描述。

## 翻译对比如下：

Summary:

- Returns evenly spaced values within the half-open interval ``[start, stop)`` as a one-dimensional tensor. 
- 返回在半开区间 ``[start, stop)`` 内元素数值均匀间隔的一维张量。

Args:

- start: if ``stop`` is specified, the start of interval (inclusive); otherwise,  the end of the interval (exclusive). If ``stop`` is not specified, the default starting value is ``0``. 
- start: 如果指定了 ``stop``, 则作为区间 ``[start, stop)`` 的起始点；如果未指定 ``stop``, 则将 ``start`` 视作区间的终止点，默认此时起始点​​为 ``0``, 即区间为 ``[0, start)``.   **<-- 为了更好理解，此处翻译做了一些变化**
- stop: the end of the interval. Default: ``None``.
- stop: 区间的终止点。 默认值： ``None``.
- step: the distance between two adjacent elements ( ``out[i+1] - out[i]`` ). Must not be 0 ; may be negative, this results i an empty tensor if stop >= start . Default: 1 . 
- step: 两个相邻元素之间的距离，即 ``out[i+1] - out[i]``.  ``step`` 不能为 0; 可能是负数，此时如果 stop >= start， 将会导致产生空的张量。 默认值：1. 

Keyword args:

- dtype( :attr:`.Tensor.dtype` ): output tensor data type. Default: ``float32``.
- dtype( :attr:`.Tensor.dtype` ): 输出张量的数据类型。默认值：  ``float32``.
- device( :attr:`.Tensor.device` ): device on which to place the created tensor. Default: ``None``.
- device( :attr:`.Tensor.device` ): 用来放置所创建张量的设备。 默认值： ``None``.
    
Returns:
- A one-dimensional tensor containing evenly spaced values.
- 一个数值均匀间隔的一维张量。
- The length of the output tensor must be ``ceil((stop-start)/step)`` if ``stop - start`` and ``step`` have the same sign, and length 0 otherwise.
- 如果 ``stop - start`` 和 ``step`` 符号相同，则输出张量的长度为 ``ceil((stop-start)/step)`` ，否则长度为 0.