### PR TITLE
docs(mge/functional): update functional.ones docstring

### DIFF
--- a/imperative/python/megengine/functional/nn.py
+++ b/imperative/python/megengine/functional/nn.py
@@ -1587,8 +1587,8 @@ def one_hot(inp: Tensor, num_classes: int) -> Tensor:
              [0 0 1 0]
              [0 0 0 1]]
     """
-    zeros_tensor = zeros(list(inp.shape) + [num_classes], inp.dtype, inp.device)
-    ones_tensor = ones(list(inp.shape) + [1], inp.dtype, inp.device)
+    zeros_tensor = zeros(list(inp.shape) + [num_classes], dtype=inp.dtype, device=inp.device)
+    ones_tensor = ones(list(inp.shape) + [1], dtype=inp.dtype, device=inp.device)
 
     op = builtin.IndexingSetOneHot(axis=inp.ndim)
     (result,) = apply(op, zeros_tensor, inp, ones_tensor)

--- a/imperative/python/megengine/functional/tensor.py
+++ b/imperative/python/megengine/functional/tensor.py
@@ -6,7 +6,7 @@
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT ARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-from typing import Iterable, Optional, Sequence, Union
+from typing import Iterable, Optional, Sequence, Union, Tuple
 
 import numpy as np
 
@@ -148,33 +148,40 @@ def full(
     return broadcast_to(x, shape)
 
 
-def ones(shape, dtype="float32", device=None) -> Tensor:
-    r"""Returns a ones tensor with given shape.
+def ones(
+    shape: Union[int, Tuple[int, ...]], 
+    *,
+    dtype="float32", 
+    device: Optional[CompNode] = None
+) -> Tensor:
+    r"""Returns a new tensor having a specified shape and filled with ones.
 
     Args:
-        shape: a list, tuple or integer defining the shape of the output tensor.
-        dtype: the desired data type of the output tensor. Default: ``float32``.
-        device: the desired device of the output tensor. Default: if ``None``,
-            use the default device (see :func:`~.megengine.get_default_device`).
+        shape (int or sequence of ints): the shape of the output tensor.
+    
+    Keyword args:
+        dtype (:attr:`.Tensor.dtype`): output tensor data type. Default: ``float32``.
+        device (:attr:`.Tensor.device`): device on which to place the created tensor. Default: ``None``.
 
     Returns:
-        output tensor.
+        a tensor containing ones.
 
     Examples:
 
-        .. testcode::
+        >>> megengine.functional.ones(5)
+        Tensor([1. 1. 1. 1. 1.], device=xpux:0)
 
-            import megengine.functional as F
+        >>> megengine.functional.ones((5, ), dtype='int32')
+        Tensor([1 1 1 1 1], dtype=int32, device=xpux:0)
+        
+        >>> megengine.functional.ones((2, 2))
+        Tensor([[1. 1.]
+         [1. 1.]], device=xpux:0)
+        
+        >>> megengine.functional.ones([2, 1])
+        Tensor([[1.]
+         [1.]], device=xpux:0)
 
-            out = F.ones((2, 1))
-            print(out.numpy())
-
-        Outputs:
-
-        .. testoutput::
-
-            [[1.]
-             [1.]]
     """
     return full(shape, 1.0, dtype=dtype, device=device)
 


### PR DESCRIPTION
Fix: #232 
1.  按照 《Python 文档字符串风格指南》中的说明，发现 ones 在《数组 API 标准》中存在 标准定义，使用了《标准》中的文档字符串作为描述内容。
2. 修改了简述使其更清晰准确
2. 为`shape`, `dtype`和`device`添加了类型提示。
3. 使用`>>>`标准doctest风格替换掉原本的`testcode`风格样例

**翻译对比如下**：
Summary:
* Returns a tensor with given shape filled with value one
* 返回一个具有给定形状的全1张量

Args:
* shape (`list`, `tuple`, `integer`): the shape of the output tensor.
* shape (`list`, `tuple`, `integer`): 输出张量的形状.
* dtype (`str`) : the desired data type of the output tensor. Default: ``float32``.
* dtype (`str`) :输出张量的数据类型。默认值：``float32``.
* device (`Tensor.device`): the desired device of the output tensor. Default: if ``None``, use the default device (see: func:`~.megengine.get_default_device`).
* device (`Tensor.device`): 输出张量的设备。默认：如果为`None`，则使用默认设备（见函数`megengine.get_default_device`）

Returns:
* output tensor.
* 输出张量