### PR TITLE
docs(mge/functional): update functional.tensor.reshape docstring

### DIFF
--- a/imperative/python/megengine/functional/tensor.py
+++ b/imperative/python/megengine/functional/tensor.py
@@ -852,31 +852,30 @@ def transpose(inp: Tensor, pattern: Iterable[int]) -> Tensor:
 
 
 def reshape(inp: Tensor, target_shape: Iterable[int]) -> Tensor:
-    r"""Reshapes a tensor to given target shape; total number of logical elements must
-    remain unchanged
+    r"""Reshapes a tensor without changing its data.
 
     Args:
-        inp: input tensor.
-        target_shape: target shape, it can contain an element of -1 representing ``unspec_axis``.
+        inp: input tensor to reshape.
+        target_shape: target shape compatible with the original shape. One shape dimension is allowed 
+             to be `-1` . When a shape dimension is `-1` , the corresponding output tensor shape dimension 
+             must be inferred from the length of the tensor and the remaining dimensions.
+
+    Returns:
+        an output tensor having the same data type, elements, and underlying element order as `inp` .
 
     Examples:
 
-        .. testcode::
-
-            import numpy as np
-            from megengine import tensor
-            import megengine.functional as F
-            x = tensor(np.arange(12, dtype=np.int32))
-            out = F.reshape(x, (3, 4))
-            print(out.numpy())
-
-        Outputs:
-
-        .. testoutput::
-
-            [[ 0  1  2  3]
-             [ 4  5  6  7]
-             [ 8  9 10 11]]
+            >>> x = F.arange(12)
+            >>> x
+            Tensor([ 0.  1.  2.  3.  4.  5.  6.  7.  8.  9. 10. 11.], device=xpux:0)
+            >>> F.reshape(x, (3, 4))
+            Tensor([[ 0.  1.  2.  3.]
+             [ 4.  5.  6.  7.]
+             [ 8.  9. 10. 11.]], device=xpux:0)
+            >>> F.reshape(x, (2, -1))
+            Tensor([[ 0.  1.  2.  3.  4.  5.]
+             [ 6.  7.  8.  9. 10. 11.]], device=xpux:0)
+            
     """
     return inp.reshape(target_shape)
 


### PR DESCRIPTION
根据 #237  中的描述改进 megengine.functional.reshape API 文档，改进方式如下：

按照 《Python 文档字符串风格指南》中的说明，发现 reshape 在《数组 API 标准》中存在 标准定义，因此使用了《标准》中的文档字符串作为描述内容。
# 翻译对比如下
---

   Summary:

- r"""Reshapes a tensor without changing its data.

-  不改变数据的情况下对张量变形。

Args:

-  inp: input tensor to reshape.

-  inp:输入需要变形的张量。

-  target_shape: target shape compatible with the original shape. One shape dimension is allowed 
             to be -1 . When a shape dimension is -1 , the corresponding output tensor shape dimension 
             must be inferred from the length of the tensor and the remaining dimensions.

-   target_shape:目标形状需要与源形状兼容。一个目标形状的维度可以是-1。当目标形状的维度是-1时，最终输出其对应的张量的形状维度会从张量的长度和剩余维度中推算出来。

Returns:

-   an output tensor having the same data type, elements, and underlying element order as inp .

-   输出的张量与输入的张量具有相同的数据类型、元素和元素排列顺序。