### PR TITLE
docs(mge/functional): update functional.full docstring

### DIFF
--- a/imperative/python/megengine/functional/tensor.py
+++ b/imperative/python/megengine/functional/tensor.py
@@ -116,7 +116,7 @@ def full(
             the output tensor data type must be the default integer data type. If the
             value is a ``float``, the output tensor data type must be the default
             floating-point data type. If the value is a ``bool``, the output tensor 
-            must have boolean data type. Default: ``None``.
+            must be a boolean data type. Default: ``None``.
         device(:attr:`.Tensor.device`): device on which to place the created tensor. Default: ``None``.
 
     Returns:

--- a/imperative/python/megengine/functional/tensor.py
+++ b/imperative/python/megengine/functional/tensor.py
@@ -104,11 +104,13 @@ def full(
     dtype=None,
     device=None,
 ) -> Tensor:
-    r"""Creates a tensor of shape ``shape`` filled with ``value``.
+    r"""Return a tensor of shape ``shape`` filled with ``value``.
 
     Args:
         shape: output tensor shape.
         value: fill value.
+        
+    Keyword args:
         dtype: output tensor data type. If ``dtype`` is ``None``, the output tensor
             data type must be inferred from ``value``. If the value is an ``int``,
             the output tensor data type must be the default integer data type. If the
@@ -118,24 +120,19 @@ def full(
         device: device on which to place the created tensor. Default: ``None``.
 
     Returns:
-        a tensor where every element is equal to ``value``.
+        A tensor where every element is equal to ``value``.
 
     Examples:
 
-        .. testcode::
-
-            import numpy as np
-            import megengine.functional as F
-
-            out = F.full([2,3], 1.5)
-            print(out.numpy())
-
-        Outputs:
-
-        .. testoutput::
-
-            [[1.5 1.5 1.5]
-             [1.5 1.5 1.5]]
+        >>> F.full(1, 1.0)
+        Tensor([1.], device=xpux:0)
+        >>> F.full((3, 4), 0)
+        Tensor([[0. 0. 0. 0.]
+         [0. 0. 0. 0.]
+         [0. 0. 0. 0.]], device=xpux:0)
+        >>> F.full((2, 2), [1, 2])
+        Tensor([[1. 2.]
+         [1. 2.]], device=xpux:0)
     """
 
     if isinstance(shape, int):

--- a/imperative/python/megengine/functional/tensor.py
+++ b/imperative/python/megengine/functional/tensor.py
@@ -111,13 +111,13 @@ def full(
         value: fill value.
         
     Keyword args:
-        dtype: output tensor data type. If ``dtype`` is ``None``, the output tensor
+        dtype(:attr:`.Tensor.dtype`): output tensor data type. If ``dtype`` is ``None``, the output tensor
             data type must be inferred from ``value``. If the value is an ``int``,
             the output tensor data type must be the default integer data type. If the
             value is a ``float``, the output tensor data type must be the default
             floating-point data type. If the value is a ``bool``, the output tensor 
             must have boolean data type. Default: ``None``.
-        device: device on which to place the created tensor. Default: ``None``.
+        device(:attr:`.Tensor.device`): device on which to place the created tensor. Default: ``None``.
 
     Returns:
         A tensor where every element is equal to ``value``.

--- a/imperative/python/megengine/functional/tensor.py
+++ b/imperative/python/megengine/functional/tensor.py
@@ -101,26 +101,31 @@ def eye(N, M=None, *, dtype="float32", device: Optional[CompNode] = None) -> Ten
 def full(
     shape: Union[int, tuple, list],
     value: Union[bool, int, float, Tensor],
+    *,
     dtype=None,
     device=None,
 ) -> Tensor:
-    r"""Return a tensor of shape ``shape`` filled with ``value``.
+    r"""Returns a new tensor having a specified ``shape`` and filled with ``value``.
 
     Args:
-        shape: output tensor shape.
-        value: fill value.
+        shape (int or sequence of ints): output tensor shape.
+        value (Number): fill value.
         
     Keyword args:
-        dtype(:attr:`.Tensor.dtype`): output tensor data type. If ``dtype`` is ``None``, the output tensor
+        dtype (:attr:`.Tensor.dtype`): output tensor data type. If ``dtype`` is ``None``, the output tensor
             data type must be inferred from ``value``. If the value is an ``int``,
             the output tensor data type must be the default integer data type. If the
             value is a ``float``, the output tensor data type must be the default
-            floating-point data type. If the value is a ``bool``, the output tensor 
-            must be a boolean data type. Default: ``None``.
-        device(:attr:`.Tensor.device`): device on which to place the created tensor. Default: ``None``.
+            floating-point data type. If the value is a ``bool``, the output array 
+            must have boolean data type. Default: ``None``.
+        device (:attr:`.Tensor.device`): device on which to place the created tensor. Default: ``None``.
 
     Returns:
         A tensor where every element is equal to ``value``.
+    
+    Note:
+        If ``dtype`` is ``None`` and the ``value`` exceeds the precision of the resolved default output array data type, 
+        behavior is left unspecified and, thus, implementation-defined.
 
     Examples:
 
@@ -130,9 +135,6 @@ def full(
         Tensor([[0. 0. 0. 0.]
          [0. 0. 0. 0.]
          [0. 0. 0. 0.]], device=xpux:0)
-        >>> F.full((2, 2), [1, 2])
-        Tensor([[1. 2.]
-         [1. 2.]], device=xpux:0)
     """
 
     if isinstance(shape, int):


### PR DESCRIPTION
fix：https://github.com/MegEngine/MegEngine/issues/234

该 API 为 MegEngine Tensor 生成操作相关的 API, 对应文档页面在 [megengine.functional.full](https://megengine.org.cn/doc/stable/zh/reference/api/megengine.functional.full.html)

参考 [《Python 文档字符串风格指南》](https://megengine.org.cn/doc/stable/zh/development/docs/python-docstring-style-guide.html)做了以下修改：

- 为了与其他API描述一致，对文字描述做了少量修改。
- 替换掉了 testcode 风格的样例，使用 >>> 标准 doctest 风格。

## 翻译对比如下：
Summary:

- Return a tensor of shape ``shape`` filled with ``value``.
返回一个形状为``shape``，值为``value``的张量

Args:

- shape: output tensor shape.
shape: 输出张量的形状。
- value: fill value.
value: 输出张量的填充值。

Keyword args:

- dtype(:attr:`.Tensor.dtype`): output tensor data type. If ``dtype`` is ``None``, the output tensor data type must be inferred from ``value``. If the value is an ``int``, the output tensor data type must be the default integer data type. If the value is a ``float``, the output tensor data type must be the default floating-point data type. If the value is a ``bool``, the output tensor must be a boolean data type. Default: ``None``.
 dtype(:attr:`.Tensor.dtype`): 输出张量的类型。如果``dtype``的值为 ``None``，输出张量数据类型会从``value``推断出来。如果值是一个``int``，输出张量数据类型必须是默认的整数数据类型。如果值是一个``float``，输出张量数据类型必须是默认的浮点数据类型。如果值是一个``bool``，输出张量必须是布尔数据类型。默认值：``None``。

- device(:attr:`.Tensor.device`): device on which to place the created tensor. Default: ``None``.
device(:attr:`.Tensor.device`): 用来放置所创建张量的设备。 默认值： ``None``。

Returns:
- A tensor where every element is equal to ``value``.
一个每个元素都等于``value``的张量。
