### PR TITLE
docs(mge/functional): update functional.zeros docstring

### DIFF
--- a/imperative/python/megengine/functional/nn.py
+++ b/imperative/python/megengine/functional/nn.py
@@ -1587,9 +1587,7 @@ def one_hot(inp: Tensor, num_classes: int) -> Tensor:
              [0 0 1 0]
              [0 0 0 1]]
     """
-    zeros_tensor = zeros(
-        list(inp.shape) + [num_classes], dtype=inp.dtype, device=inp.device
-    )
+    zeros_tensor = zeros(list(inp.shape) + [num_classes], dtype=inp.dtype, device=inp.device)
     ones_tensor = ones(list(inp.shape) + [1], dtype=inp.dtype, device=inp.device)
 
     op = builtin.IndexingSetOneHot(axis=inp.ndim)

--- a/imperative/python/megengine/functional/tensor.py
+++ b/imperative/python/megengine/functional/tensor.py
@@ -195,14 +195,28 @@ def ones(
     return full(shape, 1.0, dtype=dtype, device=device)
 
 
-def zeros(shape, dtype="float32", device=None) -> Tensor:
-    r"""Returns a zero tensor with given shape.
+def zeros(
+    shape: Union[int, Tuple[int, ...]],
+    *,
+    dtype="float32",
+    device: Optional[CompNode] = None
+) -> Tensor:
+    r"""Returns a new tensor having a specified shape and filled with zeros.
 
     Args:
-        shape: a list, tuple or integer defining the shape of the output tensor.
-        dtype: the desired data type of the output tensor. Default: ``float32``.
-        device: the desired device of the output tensor. Default: if ``None``,
-            use the default device (see :func:`~.megengine.get_default_device`).
+        shape (int or sequence of ints): the shape of the output tensor.
+
+    Keyword args:
+        dtype (:attr:`.Tensor.dtype`): output tensor data type. Default: ``float32``.
+        device (:attr:`.Tensor.device`): device on which to place the created tensor. Default: ``None``.
+
+    Returns:
+        a tensor containing zeros.
+
+    Examples:
+        >>> F.zeros((2, 1))
+        Tensor([[0.]
+         [0.]], device=xpux:0)
     """
     return full(shape, 0.0, dtype=dtype, device=device)
 


### PR DESCRIPTION
Fix: #230

- 按照[《Python 文档字符串风格指南》](https://megengine.org.cn/doc/stable/zh/development/docs/python-docstring-style-guide.html)中的说明，发现`zeros`在《数组 API 标准》中存在[标准定义](https://data-apis.org/array-api/latest/API_specification/creation_functions.html#zeros-shape-dtype-none-device-none)，因此使用了《标准》中的文档字符串作为描述内容。
- 为`shape`、`device`新增了类型提示
- 用`>>>`标准doctest风格替换了原本的`testcode`风格样例


### 翻译对比如下：
---
Summary:

- Returns a new tensor having a specified shape and filled with zeros.
- 返回一个具有指定形状的全0张量。

Args:
- shape (`int` or sequence of ints): the shape of the output tensor.
- shape (`int` or sequence of ints): 输出张量的形状.

Keyword args:
- dtype (:attr:`.Tensor.dtype`): output tensor data type. Default: ``float32``.
- dtype( :attr:`.Tensor.dtype`): 输出张量的数据类型。默认值：`float32`.

- device (:attr:`.Tensor.device`): device on which to place the created tensor. Default: ``None``.
- device( :attr:`.Tensor.device`): 用来放置所创建张量的设备。默认值：`None`.

Returns:

- a tensor containing zeros.
- 一个全0张量。