### PR TITLE
fix the type error of pixel shuffle

### DIFF
--- a/imperative/python/megengine/functional/nn.py
+++ b/imperative/python/megengine/functional/nn.py
@@ -1889,7 +1889,7 @@ def pixel_shuffle(inp: Tensor, upscale_factor: int) -> Tensor:
     )
     shape_1 = (
         *high_dim,
-        shape_ori[-3] / square,
+        int(shape_ori[-3] / square),
         shape_ori[-2] * upscale_factor,
         shape_ori[-1] * upscale_factor,
     )
@@ -1898,8 +1898,8 @@ def pixel_shuffle(inp: Tensor, upscale_factor: int) -> Tensor:
 
     layerPixelShuffle = _get_layerPixelShuffle(_device, _dtype, dim_order)
 
-    shape_0 = convert_single_value(shape_0, dtype=inp.dtype, device=inp.device)
-    shape_1 = convert_single_value(shape_1, dtype=inp.dtype, device=inp.device)
+    shape_0 = convert_single_value(shape_0, device=inp.device)
+    shape_1 = convert_single_value(shape_1, device=inp.device)
     outvar, *_ = apply(layerPixelShuffle(), inp, shape_0, shape_1)
 
     return outvar


### PR DESCRIPTION
在nn.py关于pixel shuffle的实现部分有类型转换问题，因为shape本身即为int类型所以这应该不需要转换dtype，仅切换device即可。