### PR TITLE
fix(scripts): update the pip url for python36

### DIFF
--- a/cmake/cudnn.cmake
+++ b/cmake/cudnn.cmake
@@ -6,7 +6,7 @@ endif()
 if("${CUDNN_ROOT_DIR}" STREQUAL "" AND NOT "$ENV{CUDNN_ROOT_DIR}" STREQUAL "")
   set(CUDNN_ROOT_DIR $ENV{CUDNN_ROOT_DIR})
 endif()
-
+message("CUDNN ROOT: " ${CUDNN_ROOT_DIR})
 if(MGE_CUDA_USE_STATIC AND NOT MGE_WITH_CUDNN_SHARED)
   find_library(
     CUDNN_LIBRARY
@@ -14,16 +14,19 @@ if(MGE_CUDA_USE_STATIC AND NOT MGE_WITH_CUDNN_SHARED)
     PATHS ${ALTER_LD_LIBRARY_PATHS} ${CUDNN_ROOT_DIR} ${PC_CUDNN_LIBRARY_DIRS}
           ${CMAKE_INSTALL_PREFIX}
     HINTS ${ALTER_LIBRARY_PATHS}
-    PATH_SUFFIXES lib lib64
+    PATH_SUFFIXES lib lib64 lib/x64
     DOC "CUDNN library.")
 else()
+  if(MSVC)
+        SET(CMAKE_FIND_LIBRARY_SUFFIXES ".dll")
+  endif()
   find_library(
     CUDNN_LIBRARY
-    NAMES libcudnn.so libcudnn.dylib cudnn64.dll
+    NAMES libcudnn.so libcudnn.dylib cudnn64_8.dll cudnn.dll cudnn64_8 cudnn
     PATHS ${ALTER_LD_LIBRARY_PATHS} ${CUDNN_ROOT_DIR} ${PC_CUDNN_LIBRARY_DIRS}
           ${CMAKE_INSTALL_PREFIX}
     HINTS ${ALTER_LIBRARY_PATHS}
-    PATH_SUFFIXES lib lib64
+    PATH_SUFFIXES lib lib64 bin
     DOC "CUDNN library.")
 endif()
 

--- a/cmake/tensorrt.cmake
+++ b/cmake/tensorrt.cmake
@@ -18,22 +18,25 @@ if(MGE_CUDA_USE_STATIC)
     PATH_SUFFIXES lib lib64
     DOC "TRT plugin library.")
 else()
+  if(MSVC)
+        SET(CMAKE_FIND_LIBRARY_SUFFIXES ".dll")
+  endif()
   find_library(
     TRT_LIBRARY
-    NAMES libnvinfer.so libnvinfer.dylib nvinfer.dll
+    NAMES libnvinfer.so libnvinfer.dylib nvinfer.dll nvinfer
     PATHS ${ALTER_LD_LIBRARY_PATHS} ${TRT_ROOT_DIR} ${CMAKE_INSTALL_PREFIX}
-    HINTS ${ALTER_LIBRARY_PATHS}
-    PATH_SUFFIXES lib lib64
+    HINTS ${ALTER_LIBRARY_PATHS} 
+    PATH_SUFFIXES lib lib64 
     DOC "TRT library.")
   find_library(
     TRT_PLUGIN_LIBRARY
-    NAMES libnvinfer_plugin.so libnvinfer_plugin.dylib nvinfer_plugin.dll
+    NAMES libnvinfer_plugin.so libnvinfer_plugin.dylib nvinfer_plugin.dll nvinfer_plugin
     PATHS ${ALTER_LD_LIBRARY_PATHS} ${TRT_ROOT_DIR} ${CMAKE_INSTALL_PREFIX}
     HINTS ${ALTER_LIBRARY_PATHS}
     PATH_SUFFIXES lib lib64
     DOC "TRT plugin library.")
 endif()
-
+message("TRT_LIBRARY" ${TRT_LIBRARY})
 if(TRT_LIBRARY STREQUAL "TRT_LIBRARY-NOTFOUND")
   message(
     FATAL_ERROR
@@ -121,7 +124,7 @@ if(TensorRT_VERSION_MAJOR GREATER_EQUAL 7)
   if(MGE_CUDA_USE_STATIC)
     find_library(
       LIBMYELIN_COMPILER
-      NAMES libmyelin_compiler_static.a myelin_compiler_static.lib
+      NAMES libmyelin_compiler_static.a myelin_compiler_static.lib myelin64_1.lib myelin64_1
       PATHS ${__found_trt_root}/lib)
     if(LIBMYELIN_COMPILER STREQUAL "LIBMYELIN_COMPILER-NOTFOUND")
       message(FATAL_ERROR "Can not find LIBMYELIN_COMPILER Library")
@@ -134,7 +137,7 @@ if(TensorRT_VERSION_MAJOR GREATER_EQUAL 7)
 
     find_library(
       LIBMYELIN_EXECUTOR
-      NAMES libmyelin_executor_static.a myelin_executor_static.lib
+      NAMES libmyelin_executor_static.a myelin_executor_static.lib myelin64_1.lib myelin64_1
       PATHS ${__found_trt_root}/lib)
     if(LIBMYELIN_EXECUTOR STREQUAL "LIBMYELIN_EXECUTOR-NOTFOUND")
       message(FATAL_ERROR "Can not find LIBMYELIN_EXECUTOR Library")
@@ -147,7 +150,7 @@ if(TensorRT_VERSION_MAJOR GREATER_EQUAL 7)
 
     find_library(
       LIBMYELIN_PATTERN_RUNTIME
-      NAMES libmyelin_pattern_runtime_static.a myelin_pattern_runtime_static.lib
+      NAMES libmyelin_pattern_runtime_static.a myelin_pattern_runtime_static.lib myelin64_1.lib myelin64_1
       PATHS ${__found_trt_root}/lib)
     if(LIBMYELIN_PATTERN_RUNTIME STREQUAL "LIBMYELIN_PATTERN_RUNTIME-NOTFOUND")
       message(FATAL_ERROR "Can not find LIBMYELIN_PATTERN_RUNTIME Library")
@@ -161,7 +164,7 @@ if(TensorRT_VERSION_MAJOR GREATER_EQUAL 7)
 
     find_library(
       LIBMYELIN_PATTERN_LIBRARY
-      NAMES libmyelin_pattern_library_static.a myelin_pattern_library_static.lib
+      NAMES libmyelin_pattern_library_static.a myelin_pattern_library_static.lib myelin64_1.lib myelin64_1
       PATHS ${__found_trt_root}/lib)
     if(LIBMYELIN_PATTERN_LIBRARY STREQUAL "LIBMYELIN_PATTERN_LIBRARY-NOTFOUND")
       message(FATAL_ERROR "Can not find LIBMYELIN_PATTERN_LIBRARY Library")
@@ -175,7 +178,7 @@ if(TensorRT_VERSION_MAJOR GREATER_EQUAL 7)
   else()
     find_library(
       LIBMYELIN_SHARED
-      NAMES libmyelin.so myelin.dll
+      NAMES libmyelin.so myelin.dll myelin64_1.dll myelin64_1
       PATHS ${__found_trt_root}/lib)
 
     if(LIBMYELIN_SHARED STREQUAL "LIBMYELIN_SHARED-NOTFOUND")

--- a/scripts/whl/manylinux2014/init_image.sh
+++ b/scripts/whl/manylinux2014/init_image.sh
@@ -2,6 +2,7 @@
 
 GET_PIP_URL='https://bootstrap.pypa.io/get-pip.py'
 GET_PIP_URL_35='https://bootstrap.pypa.io/pip/3.5/get-pip.py'
+GET_PIP_URL_36='https://bootstrap.pypa.io/pip/3.6/get-pip.py'
 SWIG_URL='https://codeload.github.com/swig/swig/tar.gz/refs/tags/rel-3.0.12'
 LLVM_URL='https://github.com/llvm-mirror/llvm/archive/release_60.tar.gz' 
 CLANG_URL='https://github.com/llvm-mirror/clang/archive/release_60.tar.gz'
@@ -29,6 +30,9 @@ do
     PIP_URL=${GET_PIP_URL}
     if [ ${ver} = "35m" ];then
         PIP_URL=${GET_PIP_URL_35}
+    else if [ ${ver} = "36m" ];then
+    	PIP_URL=${GET_PIP_URL_36}
+      fi
     fi
     echo "use pip url: ${PIP_URL}"
     curl ${PIP_URL} | /opt/python/cp${python_ver}-cp${ver}/bin/python - \


### PR DESCRIPTION
Python 3.6的pip下载链接已更新为 https://bootstrap.pypa.io/pip/3.6/get-pip.py
同时修改cudnn和tensorrt的cmake文件以兼容后续版本