### PR TITLE
fix(doc): link in docstring incorrect

### DIFF
--- a/imperative/python/megengine/module/normalization.py
+++ b/imperative/python/megengine/module/normalization.py
@@ -77,7 +77,7 @@ class GroupNorm(Module):
 
 class InstanceNorm(Module):
     r"""Applies Instance Normalization over a mini-batch of inputs
-    Refer to `Instance Normalization https://arxiv.org/abs/1607.08022`__
+    Refer to `Instance Normalization <https://arxiv.org/abs/1607.08022>`__
     
     .. math::
             y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta


### PR DESCRIPTION
hello, i found a typo(invalid link) from your official documentation. 

and i fixed it from your docstring

i love megengine. 

as a loyal follower of megengine, can i have some cute megengine merchandise?